### PR TITLE
fix: don't attempt to create result schemas for method without results

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,10 +15,10 @@ export const getSchemasForOpenRPCDocument = (openrpcDocument: OpenrpcDocument): 
   const { methods } = openrpcDocument;
 
   const params = flatten((methods as MethodObject[]).map((method) => method.params));
-  const result = (methods as MethodObject[]).map((method) => method.result);
+  const results = (methods as MethodObject[]).map((method) => method.result).filter(result => result !== undefined);
 
   return params
-    .concat(result)
+    .concat(results)
     .map(({ schema }) => {
       if (schema === true || schema === false) { return schema; }
       return { ...schema };


### PR DESCRIPTION
When a method's result is omitted (for a notification), the type generator will still try to include the result in the document's schemas. This produces the following error:

TypeError [Error]: Cannot destructure property 'schema' of 'undefined' as it is undefined.

Also renamed result to results, as it contains the result of all methods in the document.